### PR TITLE
Change the centos base image name

### DIFF
--- a/images/nginx/Dockerfile
+++ b/images/nginx/Dockerfile
@@ -1,5 +1,5 @@
 # Pull base image.
-FROM melin/centos6:base
+FROM melin/centos6-base
 
 MAINTAINER melin <libinsong1204@gmail.com>
 


### PR DESCRIPTION
update the base iamge name from `melin/centos6:base` to `melin/centos6-base`
